### PR TITLE
fix: profilarr traefik name corrected

### DIFF
--- a/modules/streaming/default.nix
+++ b/modules/streaming/default.nix
@@ -183,6 +183,7 @@ in {
     prowlarrName
     quiName
     seerrName
+    profilarrName
   ];
 
   options.nps.stacks.${stackName} =
@@ -659,7 +660,7 @@ in {
           };
 
           port = 6868;
-          traefik.name = seerrName;
+          traefik.name = profilarrName;
           stack = stackName;
           homepage = {
             inherit category;


### PR DESCRIPTION
I noticed profilarr used the seerrName as traefik.name.
This MR fixed the incorrect configuration.

Fixes: #987 