### PR TITLE
override: add fs notifier toggle so that authelia smtp can be enabled

### DIFF
--- a/modules/authelia/default.nix
+++ b/modules/authelia/default.nix
@@ -179,7 +179,6 @@ in {
     };
     settings = lib.mkOption {
       type = yaml.type;
-
       description = ''
         Additional Authelia settings. Will be provided in the `configuration.yml`.
       '';
@@ -213,13 +212,6 @@ in {
         The middleware will utilize the ForwardAuth Authz implementation.
 
         See <https://www.authelia.com/integration/proxies/traefik/#implementation>
-      '';
-    };
-    enableFilesystemNotifier = lib.mkOption {
-      type = lib.types.bool;
-      default = true;
-      description = ''
-        Whether to enable the default filesystem notifier, as this collides with the SMTP notifier.
       '';
     };
     crowdsec = {
@@ -300,9 +292,9 @@ in {
         password_change.disable = lib.mkDefault true;
       };
       access_control.default_policy = lib.mkDefault config.nps.stacks.${name}.defaultAllowPolicy;
-      notifier = lib.mkIf cfg.enableFilesystemNotifier {
-        filesystem.filename = "/notifier/notification.txt";
-      };
+
+      # Make entire notifier block with default prioority, so configured smtp settings will override the filesystem notifier, since Authelia only supports a single configured notifier
+      notifier = lib.mkDefault {filesystem.filename = "/notifier/notification.txt";};
       session =
         {
           name = "authelia_session";
@@ -344,7 +336,7 @@ in {
 
     services.podman.containers = {
       ${name} = {
-        image = "ghcr.io/authelia/authelia:4.39.19";
+        image = "ghcr.io/authelia/authelia:4.39.20";
         environment =
           {
             AUTHELIA_STORAGE_LOCAL_PATH = "/data/db.sqlite3";

--- a/modules/authelia/default.nix
+++ b/modules/authelia/default.nix
@@ -215,6 +215,13 @@ in {
         See <https://www.authelia.com/integration/proxies/traefik/#implementation>
       '';
     };
+    enableFilesystemNotifier = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = ''
+        Whether to enable the default filesystem notifier, as this collides with the SMTP notifier.
+      '';
+    };
     crowdsec = {
       enableLogCollection = lib.mkOption {
         type = lib.types.bool;
@@ -293,7 +300,9 @@ in {
         password_change.disable = lib.mkDefault true;
       };
       access_control.default_policy = lib.mkDefault config.nps.stacks.${name}.defaultAllowPolicy;
-      notifier.filesystem.filename = "/notifier/notification.txt";
+      notifier = lib.mkIf cfg.enableFilesystemNotifier {
+        filesystem.filename = "/notifier/notification.txt";
+      };
       session =
         {
           name = "authelia_session";


### PR DESCRIPTION
In Authelia, the `notifier` is a hard-requirement to be unique, with either the `filesystem` or `smtp` provider.

https://www.authelia.com/configuration/notifications/introduction/#provider-requirements

> You must configure exactly one notification provider: either `filesystem` or `smtp`. These providers are mutually exclusive - you cannot configure both at the same time.

Although this PR does not explicitly add SMTP support, with this PR, you can add something to your config like this:

```
# stacks.yaml
# ...
    stacks = {
      authelia = {
        # ...
        #enableFilesystemNotifier = false;
        settings = {
          notifier = {
            disable_startup_check = false;
            smtp = {
              address = "smtp://<address>:<port>";
              username = "<email>";
              sender = "Authelia on behalf of <>";
            };
          };
      authelia.containers.authelia.fileEnvMount = {
        AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE = {
          sourcePath = config.sops.secrets."authelia/smtp_password".path;
          destPath = "/run/secrets/AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE";
        };
      };
```

I will acknowledge that it might make more sense to have the toggle be `disableFilesystemNotifier = true`, but I already had it working this way, and `mkIf` works much better with a by-default `true` boolean rather than the other way around... This way also guarantees nothing will break for any existing users who run `nix flake update` and don't have this parameter defined.