### PR TITLE
fix(monitoring): add `alertmanager` container aliases

### DIFF
--- a/modules/monitoring/default.nix
+++ b/modules/monitoring/default.nix
@@ -69,6 +69,8 @@ in {
       prometheusName
       alloyName
       podmanExporterName
+      alertmanagerName
+      alertmanagerNtfyName
     ];
 
   options.nps.stacks.${stackName} = {


### PR DESCRIPTION
I was surprised when I tried to use `config.nps.stacks.monitoring.containers.alertmanager` and it wasn't defined, so I added the aliases.