### PR TITLE
fix(gluetun): omit null files from `extraEnv`

### DIFF
--- a/modules/streaming/default.nix
+++ b/modules/streaming/default.nix
@@ -511,8 +511,8 @@ in {
           extraEnv =
             {
               WIREGUARD_PRIVATE_KEY.fromFile = cfg.gluetun.wireguardPrivateKeyFile;
-              WIREGUARD_PRESHARED_KEY.fromFile = cfg.gluetun.wireguardPresharedKeyFile;
-              WIREGUARD_ADDRESSES.fromFile = cfg.gluetun.wireguardAddressesFile;
+              WIREGUARD_PRESHARED_KEY = lib.mkIf (cfg.gluetun.wireguardPresharedKeyFile != null) {fromFile = cfg.gluetun.wireguardPresharedKeyFile;};
+              WIREGUARD_ADDRESSES = lib.mkIf (cfg.gluetun.wireguardAddressesFile != null) {fromFile = cfg.gluetun.wireguardAddressesFile;};
             }
             // cfg.gluetun.extraEnv;
 


### PR DESCRIPTION
`wireguardPresharedKeyFile` and `wireguardAddressesFile` are already `lib.types.nullOr`, but in practice they are required because `fromFile` isn't guarded by `lib.mkIf`. This PR makes them actually optional.

For additional context, I use ProtonVPN and [only `WIREGUARD_PRIVATE_KEY` is required](https://github.com/qdm12/gluetun-wiki/blob/85f484dfa77f460964811ba6c0fffd3ca2e1dde1/setup/providers/protonvpn.md#wireguard-only).